### PR TITLE
Metadata for Marlowe's Plutus scripts.

### DIFF
--- a/projects/Marlowe.json
+++ b/projects/Marlowe.json
@@ -1,0 +1,155 @@
+{
+  "projectName": "Marlowe",
+  "labelPrefix": "Marlowe",
+  "website": "https://marlowe.iohk.io/",
+  "twitter": "marlowe_io",
+  "discord": "https://discord.gg/t8KQ2WnKSg",
+  "category": "REALFI",
+  "description": "Marlowe is an ecosystem of tools and languages to enable development of financial and transactional smart contracts.",
+  "contracts": [
+
+    {
+      "name": "Marlowe Semantics Interpreter",
+      "description" : "Interpreter for all Marlowe V1 contracts.",
+      "version": 5,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "377325ad84a55ba0282d844dff2d5f0f18c33fd4a28a0a9d73c6f60d",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Role-Payout Script",
+      "description" : "Script to validate Marlowe's payouts to a contract's roles.",
+      "version": 5,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "fcb8885eb5e4f9a5cfca3c75e8c7280e482af32dcdf2d13e47d05d27",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Open Role Script",
+      "description" : "Script for just-in-time distribution of roles in Marlowe contracts.",
+      "version": 5,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "2722e12a53dfb4fe3742b8a2c0534bd16b0b5ae492a3d76554bbe8a5",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+
+    {
+      "name": "Marlowe Semantics Interpreter",
+      "description" : "Interpreter for all Marlowe V1 contracts.",
+      "version": 4,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "6027a8010c555a4dd6b08882b899f4b3167c6e4524047132202dd984",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Role-Payout Script",
+      "description" : "Script to validate Marlowe's payouts to a contract's roles.",
+      "version": 4,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "fdade3b86107bc715037b468574dd8d3f884a0da8c9956086b9a1a51",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Open Role Script",
+      "description" : "Script for just-in-time distribution of roles in Marlowe contracts.",
+      "version": 4,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "36a5c7e49a6b11c7fb65fb61db69ed5ceaa35326af9d952fd30185c0",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+
+    {
+      "name": "Marlowe Semantics Interpreter",
+      "description" : "Interpreter for all Marlowe V1 contracts.",
+      "version": 3,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "d85fa9bc2bdfd97d5ebdbc5e3fc66f7476213c40c21b73b41257f09d",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Role-Payout Script",
+      "description" : "Script to validate Marlowe's payouts to a contract's roles.",
+      "version": 3,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "10ec7e02d25f5836b3e1098e0d4d8389e71d7a97a57aa737adc1d1fa",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+    {
+      "name": "Marlowe Open Role Script",
+      "description" : "Script for just-in-time distribution of roles in Marlowe contracts.",
+      "version": 3,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "b1d61d0c8a3c0f081a7ccebf0050e3f2c9751e82a4f3953a769dddfb",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/"
+    },
+
+    {
+      "name": "Marlowe Semantics Interpreter",
+      "description" : "Interpreter for all Marlowe V1 contracts.",
+      "version": 2,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "2ed2631dbb277c84334453c5c437b86325d371f0835a28b910a91a6e",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/",
+      "audit" : [{
+	"provider" : "IOG's Audit Response",
+	"report" : "https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/response-to-audit-report.md",
+	"date" : "24-05-2023"
+      }]
+    },
+    {
+      "name": "Marlowe Role-Payout Script",
+      "description" : "Script to validate Marlowe's payouts to a contract's roles.",
+      "version": 2,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "e165610232235bbbbeff5b998b233daae42979dec92a6722d9cda989",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/",
+      "audit" : [{
+	"provider" : "IOG's Audit Response",
+	"report" : "https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/response-to-audit-report.md",
+	"date" : "24-05-2023"
+      }]
+    },
+
+    {
+      "name": "Marlowe Semantics Interpreter",
+      "description" : "Interpreter for all Marlowe V1 contracts.",
+      "version": 1,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "6a9391d6aa51af28dd876ebb5565b69d1e83e5ac7861506bd29b56b0",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/",
+      "audit" : [{
+	"provider" : "Tweag",
+	"report" : "https://github.com/tweag/tweag-audit-reports/blob/main/Marlowe-2023-03.pdf",
+	"date" : "24-03-2023"
+      }]
+    },
+    {
+      "name": "Marlowe Role-Payout Script",
+      "description" : "Script to validate Marlowe's payouts to a contract's roles.",
+      "version": 1,
+      "language": "PLUTUS",
+      "languageVersion": 2,
+      "scriptHash": "49076eab20243dc9462511fb98a9cfb719f86e9692288139b7c91df3",
+      "github": "https://github.com/input-output-hk/marlowe-cardano/",
+      "audit" : [{
+	"provider" : "Tweag",
+	"report" : "https://github.com/tweag/tweag-audit-reports/blob/main/Marlowe-2023-03.pdf",
+	"date" : "24-03-2023"
+      }]
+    }
+
+  ]
+}
+


### PR DESCRIPTION
This pull request registers the current and historical versions of the three Marlowe validator scripts:

1. The Marlowe semantics interpreter, which is the main Marlowe script used to validate all Marlowe contracts.
2. The Marlowe role-payout script, which validates payments to the roles in Marlowe contacts.
3. The Marlowe open-role script, which validates just-in-time distribution of role tokens to parties in Marlowe contract.

The metadata here for the Marlowe scripts matches the well-known script hashes in Marlowe Runtime's script registry: https://github.com/input-output-hk/marlowe-cardano/blob/d609770f7232e696c1eebba96002398c3dc026cb/marlowe-runtime/src/Language/Marlowe/Runtime/Core/ScriptRegistry.hs#L816-L818